### PR TITLE
Reduce number of headers included with lib.h

### DIFF
--- a/c_src/shmex/lib.c
+++ b/c_src/shmex/lib.c
@@ -1,3 +1,6 @@
+// feature test macro for clock_gettime and ftruncate
+#define _POSIX_C_SOURCE 200809L
+
 #include "lib.h"
 #include <sys/mman.h>
 #include <sys/stat.h>

--- a/c_src/shmex/lib.c
+++ b/c_src/shmex/lib.c
@@ -1,4 +1,11 @@
 #include "lib.h"
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+#include <time.h>
+#include <stdio.h>
 
 void shmex_generate_name(Shmex * payload) {
   static const unsigned GENERATED_NAME_SIZE = strlen(SHM_NAME_PREFIX) + 21;

--- a/c_src/shmex/lib.h
+++ b/c_src/shmex/lib.h
@@ -3,16 +3,10 @@
 #define NAME_MAX 255
 #define _POSIX_C_SOURCE 200809L
 
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 #include <erl_nif.h>
 #include <bunch/bunch.h>
-#include <string.h>
-#include <unistd.h>
 #include <sys/types.h>
-#include <time.h>
-#include <stdio.h>
+#include <stddef.h>
 
 typedef struct {
   char * name;

--- a/c_src/shmex/lib.h
+++ b/c_src/shmex/lib.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #define NAME_MAX 255
-#define _POSIX_C_SOURCE 200809L
 
 #include <erl_nif.h>
 #include <bunch/bunch.h>


### PR DESCRIPTION
This not a good pattern to place all the headers needed by
lib.c in lib.h as lib.h is included by library users that don't need
headers like unistd.h. This can lead to naming clashes (e.g., unistd.h
defines write function)